### PR TITLE
feat: implement XREAD command to read entries from multiple streams

### DIFF
--- a/app/commands/common_utility.go
+++ b/app/commands/common_utility.go
@@ -71,6 +71,32 @@ func encodeStreamArrayString(resps []storage.StreamEntry) string {
 	return bufferString.String()
 }
 
+func encodeXreadStreamArrayString(resps map[string][]storage.StreamEntry) string {
+
+	bufferString := bytes.NewBufferString(parserModel.ARRAYS)
+	bufferString.WriteString(strconv.Itoa(len(resps)))
+	bufferString.WriteString(parserModel.STR_WRAPPER)
+
+	for key, resp := range resps {
+
+		bufferString.WriteString(parserModel.ARRAYS + "2" + parserModel.STR_WRAPPER + encodeBulkString(key))
+		bufferString.WriteString(parserModel.ARRAYS + strconv.Itoa(len(resp)) + parserModel.STR_WRAPPER)
+
+		for _, entry := range resp {
+
+			bufferString.WriteString("*2" + parserModel.STR_WRAPPER + encodeBulkString(entry.ID))
+
+			attribs := make([]string, 0)
+			for key, value := range entry.Attributes {
+				attribs = append(attribs, key, fmt.Sprintf("%v", value))
+			}
+			bufferString.WriteString(encodeArrayString(attribs))
+		}
+	}
+
+	return bufferString.String()
+}
+
 func getExpiryTimeInUTC(expire int, Timetype string) time.Time {
 	switch strings.ToLower(Timetype) {
 	case parserModel.EX:

--- a/app/models/parser.go
+++ b/app/models/parser.go
@@ -34,6 +34,7 @@ const (
 	TYPE_COMMAND         = "type"
 	XADD_COMMAND         = "xadd"
 	XRANGE_COMMAND       = "xrange"
+	XREAD_COMMAND        = "xread"
 )
 
 const (

--- a/app/storage/stream_storage.go
+++ b/app/storage/stream_storage.go
@@ -325,3 +325,15 @@ func (s *StreamStorage) GetLastEntryID(streamKey string) string {
 	entryIDs := entries.([]string)
 	return entryIDs[len(entryIDs)-1]
 }
+
+func (s *StreamStorage) XReadStreams(xReadEntries map[string]string) map[string][]StreamEntry {
+
+	var entries map[string][]StreamEntry = make(map[string][]StreamEntry)
+
+	for streamKeyName, entryID := range xReadEntries {
+
+		entries[streamKeyName] = s.GetRange(streamKeyName, entryID, "+")
+	}
+
+	return entries
+}


### PR DESCRIPTION
The code changes in this commit add support for the XREAD command. This command allows reading entries from multiple streams based on the provided stream keys and entry IDs. The `processXReadCommand` function is implemented to handle the XREAD command and return the corresponding entries from the streams.

Recent commits:
- Merge pull request #10 from JayeshBaldawa/9-xadd-create-a-stream: add XADD Support
- add XADD Support
- Delete app/logs/2024-04-21 directory
- Merge pull request #8 from JayeshBaldawa/7-wait-with-multiple-commands: implement wait functionality with multiple commands
- implement wait functionality with multiple commands
- Merge pull request #6 from JayeshBaldawa/5-wait-with-no-commands: wait cmd that gives back the connected replicas
- wait cmd that gives back the connected replicas
- Merge pull request #4 from JayeshBaldawa/3-wait-with-no-replicas: add support for wait command
- add support for wait command
- Merge pull request #2 from JayeshBaldawa/1-acks-with-no-commands: add ack support | refactor code | processed bytes support as well