### PR TITLE
feat: Support for BLOCK Command with sync and stream support for XREAD

### DIFF
--- a/app/commands/common_utility.go
+++ b/app/commands/common_utility.go
@@ -71,13 +71,15 @@ func encodeStreamArrayString(resps []storage.StreamEntry) string {
 	return bufferString.String()
 }
 
-func encodeXreadStreamArrayString(resps map[string][]storage.StreamEntry) string {
+func encodeXreadStreamArrayString(resps map[string][]storage.StreamEntry, orderOfKeys []string) string {
 
 	bufferString := bytes.NewBufferString(parserModel.ARRAYS)
 	bufferString.WriteString(strconv.Itoa(len(resps)))
 	bufferString.WriteString(parserModel.STR_WRAPPER)
 
-	for key, resp := range resps {
+	for _, key := range orderOfKeys {
+
+		resp := resps[key]
 
 		bufferString.WriteString(parserModel.ARRAYS + "2" + parserModel.STR_WRAPPER + encodeBulkString(key))
 		bufferString.WriteString(parserModel.ARRAYS + strconv.Itoa(len(resp)) + parserModel.STR_WRAPPER)
@@ -112,10 +114,11 @@ func getExpiryTimeInUTC(expire int, Timetype string) time.Time {
 	}
 }
 
-func formatCommandOutput(resp string, cmdName string, parameters map[string]string) parserModel.CommandOutput {
+func formatCommandOutput(resp string, cmdName string, parameters map[string]string, isStreaming bool) parserModel.CommandOutput {
 	return parserModel.CommandOutput{
 		CommandName: cmdName,
 		Response:    resp,
 		Parameters:  parameters,
+		IsStreaming: isStreaming,
 	}
 }

--- a/app/commands/master_parser.go
+++ b/app/commands/master_parser.go
@@ -3,18 +3,25 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/codecrafters-io/redis-starter-go/app/events"
+	log "github.com/codecrafters-io/redis-starter-go/app/logger"
 	parserModel "github.com/codecrafters-io/redis-starter-go/app/models"
 	storage "github.com/codecrafters-io/redis-starter-go/app/storage"
 	config "github.com/codecrafters-io/redis-starter-go/app/utility"
+	"github.com/google/uuid"
 )
 
 type MasterParser struct{}
 
-func (masterParser *MasterParser) ProcessArrayCommand(strCommand []string, numElements int) (parserModel.CommandOutput, error) {
+func (masterParser *MasterParser) ProcessArrayCommand(input parserModel.CommandInput, numElements int) (parserModel.CommandOutput, error) {
+
+	strCommand := input.SplittedCommand
+
 	// Ensure at least one command is provided
 	if len(strCommand) < 1 {
 		return parserModel.CommandOutput{}, errors.New("no command provided")
@@ -24,41 +31,41 @@ func (masterParser *MasterParser) ProcessArrayCommand(strCommand []string, numEl
 	command := strings.ToLower(strCommand[0])
 	switch command {
 	case parserModel.ECHO_COMMAND:
-		return formatCommandOutput(encodeBulkString(getCommandParameter(strCommand, 1)), parserModel.ECHO_COMMAND, nil), nil
+		return formatCommandOutput(encodeBulkString(getCommandParameter(strCommand, 1)), parserModel.ECHO_COMMAND, nil, false), nil
 
 	case parserModel.PING_COMMAND:
-		return formatCommandOutput(encodeSimpleString("PONG"), parserModel.PING_COMMAND, nil), nil
+		return formatCommandOutput(encodeSimpleString("PONG"), parserModel.PING_COMMAND, nil, false), nil
 
 	case parserModel.SET_COMMAND:
 		resp, err := masterParser.processSetCommand(strCommand, numElements)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.SET_COMMAND, nil), nil
+		return formatCommandOutput(resp, parserModel.SET_COMMAND, nil, false), nil
 
 	case parserModel.GET_COMMAND:
 		resp, err := masterParser.processGetCommand(strCommand)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.GET_COMMAND, nil), nil
+		return formatCommandOutput(resp, parserModel.GET_COMMAND, nil, false), nil
 
 	case parserModel.INFO_COMMAND:
 		resp, err := masterParser.processInfoCommand(strCommand)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.INFO_COMMAND, nil), nil
+		return formatCommandOutput(resp, parserModel.INFO_COMMAND, nil, false), nil
 
 	case parserModel.REPLCONF:
 		resp, err := masterParser.checkReplconCommand(strCommand)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.REPLCONF, nil), nil
+		return formatCommandOutput(resp, parserModel.REPLCONF, nil, false), nil
 
 	case parserModel.PYSNC:
-		return formatCommandOutput(masterParser.handlePysncCommand(), parserModel.PYSNC, nil), nil
+		return formatCommandOutput(masterParser.handlePysncCommand(), parserModel.PYSNC, nil, false), nil
 
 	case parserModel.WAIT:
 		replicaServersCount, err := strconv.Atoi(strCommand[1])
@@ -76,34 +83,39 @@ func (masterParser *MasterParser) ProcessArrayCommand(strCommand []string, numEl
 			parserModel.WAIT_REPLICAS_COUNT: fmt.Sprint(replicaServersCount),
 		}
 
-		return formatCommandOutput(encodeIntegerString(replicaServersCount), parserModel.WAIT, mapReplicaServers), nil
+		return formatCommandOutput(encodeIntegerString(replicaServersCount), parserModel.WAIT, mapReplicaServers, false), nil
 
 	case parserModel.TYPE_COMMAND:
 		typeOfValue, err := processTypeCommand(strCommand[1])
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(typeOfValue, parserModel.TYPE_COMMAND, nil), nil
+		return formatCommandOutput(typeOfValue, parserModel.TYPE_COMMAND, nil, false), nil
 	case parserModel.XADD_COMMAND:
 		resp, err := masterParser.processSetStream(strCommand, numElements)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.XADD_COMMAND, nil), nil
+		return formatCommandOutput(resp, parserModel.XADD_COMMAND, nil, false), nil
 
 	case parserModel.XRANGE_COMMAND:
 		resp, err := masterParser.processXRangeCommand(strCommand)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.XRANGE_COMMAND, nil), nil
+		return formatCommandOutput(resp, parserModel.XRANGE_COMMAND, nil, false), nil
 
 	case parserModel.XREAD_COMMAND:
-		resp, err := masterParser.processXReadCommand(strCommand)
+		resp, isStreaming, err := masterParser.processXReadCommand(strCommand, input.Conn)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.XREAD_COMMAND, nil), nil
+		if isStreaming {
+			return formatCommandOutput(resp, parserModel.XREAD_COMMAND, map[string]string{
+				parserModel.XREAD_TOPIC: uuid.New().String(),
+			}, isStreaming), nil
+		}
+		return formatCommandOutput(resp, parserModel.XREAD_COMMAND, nil, isStreaming), nil
 
 	default:
 		return parserModel.CommandOutput{}, errors.New("unknown command")
@@ -249,22 +261,108 @@ func (masterParser *MasterParser) processXRangeCommand(strCommand []string) (str
 	return encodeStreamArrayString(entries), nil
 }
 
-func (masterParser *MasterParser) processXReadCommand(strCommand []string) (string, error) {
+func (masterParser *MasterParser) processXReadCommand(strCommand []string, conn net.Conn) (string, bool, error) {
+
 	if len(strCommand) < 4 {
-		return "", errors.New("invalid format for XREAD command")
+		return "", false, errors.New("invalid format for XREAD command")
+	}
+
+	// Check if there are any optional argument
+	switch strings.ToLower(strCommand[1]) {
+	case parserModel.XREAD_COMMAND_BLOCK:
+		return handleXreadBlockCommand(strCommand, conn)
 	}
 
 	streams := make(map[string]string)
 	numToRun := (len(strCommand) - 2) / 2
 
+	orderOfKeys := make([]string, 0)
+
 	for i := 0; i < numToRun; i++ {
 		streams[strCommand[i+2]] = strCommand[i+2+numToRun]
+		orderOfKeys = append(orderOfKeys, strCommand[i+2])
 	}
 
 	entries := storage.GetStreamStorage().XReadStreams(streams)
 	if len(entries) == 0 {
-		return encodeNullBulkString(), nil
+		return encodeNullBulkString(), false, nil
 	}
 
-	return encodeXreadStreamArrayString(entries), nil
+	return encodeXreadStreamArrayString(entries, orderOfKeys), false, nil
+}
+
+func handleXreadBlockCommand(strCommand []string, conn net.Conn) (string, bool, error) {
+	//xread block 1000 streams some_key 1526985054069-0
+	if len(strCommand) < 5 {
+		return encodeErrorString(errors.New("invalid format for XREAD BLOCK command")), false, nil
+	}
+
+	// Get the timeout value
+	timeout, err := strconv.Atoi(strCommand[2])
+	if err != nil {
+		return encodeErrorString(errors.New("invalid format for timeout value")), false, nil
+	}
+
+	// Check if the timeout value is valid
+	if timeout < 0 {
+		return encodeErrorString(errors.New("timeout value should be greater than 0")), false, nil
+	}
+
+	// GetStreamKeyName
+	streamKey := strCommand[4]
+	entryId := strCommand[5]
+
+	if timeout == 0 {
+		go StreamXReadBlock(streamKey, entryId, timeout, conn)
+		return "", true, nil
+	}
+
+	entries, err := storage.GetStreamStorage().XReadStreamsBlock(streamKey, entryId, timeout)
+
+	if err != nil {
+		return encodeErrorString(err), false, nil
+	}
+
+	if len(entries) == 0 {
+		return encodeNullBulkString(), false, nil
+	}
+
+	return encodeXreadStreamArrayString(entries, []string{streamKey}), false, nil
+}
+
+func StreamXReadBlock(streamKey string, entryId string, timeout int, conn net.Conn) {
+
+	topic := fmt.Sprintf("%s:%s:%s", parserModel.XREAD_STREAM_TOPIC, streamKey, uuid.New().String())
+
+	log.LogInfo(fmt.Sprintf("Subscribing to topic: %s", topic))
+
+	subChan := events.GetPubSub().Subscribe(topic)
+	defer events.GetPubSub().Unsubscribe(topic, subChan)
+
+	defaultTimeoutMs := 1000000 // 16666.6667
+
+	timeout = defaultTimeoutMs
+
+	go storage.GetStreamStorage().XReadStreamsBlock(streamKey, entryId, timeout, topic)
+
+	for {
+		select {
+		case <-time.After(time.Duration(defaultTimeoutMs) * time.Millisecond):
+			return
+		case data := <-subChan:
+			log.LogInfo(fmt.Sprintf("Received data from topic: %v", data))
+			entries, ok := data.Data.(storage.StreamEntry)
+			if !ok {
+				// Check to stop the stream
+				stopCmd, ok := data.Data.(string)
+				if ok && stopCmd == "STOP" {
+					return
+				}
+			}
+
+			// Write the data to the connection
+			conn.Write([]byte(encodeXreadStreamArrayString(map[string][]storage.StreamEntry{streamKey: {entries}}, []string{streamKey})))
+		}
+	}
+
 }

--- a/app/commands/slave_parser.go
+++ b/app/commands/slave_parser.go
@@ -14,7 +14,10 @@ import (
 
 type SlaveParser struct{}
 
-func (slaveParser *SlaveParser) ProcessArrayCommand(strCommand []string, numElements int) (parserModel.CommandOutput, error) {
+func (slaveParser *SlaveParser) ProcessArrayCommand(input parserModel.CommandInput, numElements int) (parserModel.CommandOutput, error) {
+
+	strCommand := input.SplittedCommand
+
 	// Ensure at least one command is provided
 	if len(strCommand) < 1 {
 		return parserModel.CommandOutput{}, errors.New("no command provided")
@@ -25,33 +28,33 @@ func (slaveParser *SlaveParser) ProcessArrayCommand(strCommand []string, numElem
 
 	switch command {
 	case parserModel.ECHO_COMMAND:
-		return formatCommandOutput(encodeBulkString(getCommandParameter(strCommand, 1)), parserModel.ECHO_COMMAND, nil), nil
+		return formatCommandOutput(encodeBulkString(getCommandParameter(strCommand, 1)), parserModel.ECHO_COMMAND, nil, false), nil
 	case parserModel.PING_COMMAND:
-		return formatCommandOutput(encodeSimpleString("PONG"), parserModel.PING_COMMAND, nil), nil
+		return formatCommandOutput(encodeSimpleString("PONG"), parserModel.PING_COMMAND, nil, false), nil
 	case parserModel.INFO_COMMAND:
 		resp, err := slaveParser.processInfoCommand(strCommand)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.INFO_COMMAND, nil), nil
+		return formatCommandOutput(resp, parserModel.INFO_COMMAND, nil, false), nil
 	case parserModel.SET_COMMAND:
 		resp, err := slaveParser.processSetCommand(strCommand, numElements)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.SET_COMMAND, nil), nil
+		return formatCommandOutput(resp, parserModel.SET_COMMAND, nil, false), nil
 	case parserModel.GET_COMMAND:
 		resp, err := slaveParser.processGetCommand(strCommand)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.GET_COMMAND, nil), nil
+		return formatCommandOutput(resp, parserModel.GET_COMMAND, nil, false), nil
 	case parserModel.REPLCONF:
 		resp, err := slaveParser.processReplconfCommand(strCommand)
 		if err != nil {
 			return parserModel.CommandOutput{}, err
 		}
-		return formatCommandOutput(resp, parserModel.GETACK, nil), nil
+		return formatCommandOutput(resp, parserModel.GETACK, nil, false), nil
 	default:
 		return parserModel.CommandOutput{}, errors.New("unknown command")
 	}

--- a/app/events/pubsub.go
+++ b/app/events/pubsub.go
@@ -1,0 +1,90 @@
+package events
+
+// Event represents an event with a specific topic.
+type Event struct {
+	Topic string
+	Data  interface{}
+}
+
+// PubSub represents a pub/sub system with support for topics.
+type PubSub struct {
+	subscribers map[string][]chan Event // Map of topics to subscriber channels
+	newSub      chan subRequest         // Channel for new subscriber requests
+	delSub      chan subRequest         // Channel for subscriber removal requests
+	events      chan Event              // Channel for incoming events
+}
+
+// subRequest represents a subscription request.
+type subRequest struct {
+	topic string
+	sub   chan Event
+}
+
+var pubSub *PubSub
+
+func init() {
+	pubSub = NewPubSub()
+}
+
+func GetPubSub() *PubSub {
+	return pubSub
+}
+
+// NewPubSub creates a new instance of the pub/sub system.
+func NewPubSub() *PubSub {
+	ps := &PubSub{
+		subscribers: make(map[string][]chan Event),
+		newSub:      make(chan subRequest),
+		delSub:      make(chan subRequest),
+		events:      make(chan Event),
+	}
+	go ps.start()
+	return ps
+}
+
+// start starts the pub/sub system's event processing loop.
+func (ps *PubSub) start() {
+	for {
+		select {
+		case req := <-ps.newSub:
+			ps.subscribers[req.topic] = append(ps.subscribers[req.topic], req.sub)
+		case req := <-ps.delSub:
+			subscribers := ps.subscribers[req.topic]
+			for i, sub := range subscribers {
+				if sub == req.sub {
+					// Remove the subscriber
+					subscribers[i] = subscribers[len(subscribers)-1]
+					subscribers = subscribers[:len(subscribers)-1]
+					ps.subscribers[req.topic] = subscribers
+					break
+				}
+			}
+		case event := <-ps.events:
+			topic := event.Topic
+			sub, ok := ps.subscribers[topic]
+			if !ok {
+				continue
+			}
+			for _, subscriber := range sub {
+				subscriber <- event
+			}
+		}
+	}
+}
+
+// Subscribe subscribes to a specific topic to receive events.
+func (ps *PubSub) Subscribe(topic string) chan Event {
+	sub := make(chan Event)
+	ps.newSub <- subRequest{topic: topic, sub: sub}
+	return sub
+}
+
+// Unsubscribe unsubscribes from receiving events of a specific topic.
+func (ps *PubSub) Unsubscribe(topic string, sub chan Event) {
+	ps.delSub <- subRequest{topic: topic, sub: sub}
+}
+
+// Publish publishes an event with a specific topic.
+func (ps *PubSub) Publish(event Event) {
+	ps.events <- event // Send the event to the pub/sub system
+}

--- a/app/models/events_topic.go
+++ b/app/models/events_topic.go
@@ -1,0 +1,6 @@
+package models
+
+const (
+	XREAD_TOPIC        = "xread_topic"
+	XREAD_STREAM_TOPIC = "xread_stream_topic"
+)

--- a/app/models/parser.go
+++ b/app/models/parser.go
@@ -1,5 +1,7 @@
 package models
 
+import "net"
+
 const (
 	SIMPLE  = "+"
 	ERROR   = "-ERR "
@@ -38,6 +40,11 @@ const (
 )
 
 const (
+	XREAD_COMMAND_BLOCK  = "block"
+	XREAD_COMMAND_DOLLAR = "$"
+)
+
+const (
 	EX   = "ex"   // Seconds
 	PX   = "px"   // Milliseconds
 	EXAT = "exat" // Unix timestamp in seconds
@@ -48,7 +55,13 @@ type CommandOutput struct {
 	CommandName  string
 	Response     string
 	NextCommands []string
+	IsStreaming  bool
 	Parameters   map[string]string
+}
+
+type CommandInput struct {
+	SplittedCommand []string
+	Conn            net.Conn
 }
 
 const (


### PR DESCRIPTION
This commit adds two constants, XREAD_TOPIC and XREAD_STREAM_TOPIC, to the models package. These constants will be used in the implementation of the XREAD command to read entries from multiple streams.

Recent commits:
- feat: implement XREAD command to read entries from multiple streams
- feat: add XRANGE command support
- Merge pull request #10 from JayeshBaldawa/9-xadd-create-a-stream: add XADD Support
- add XADD Support
- Delete app/logs/2024-04-21 directory
- Merge pull request #8 from JayeshBaldawa/7-wait-with-multiple-commands: implement wait functionality with multiple commands
- implement wait functionality with multiple commands
- Merge pull request #6 from JayeshBaldawa/5-wait-with-no-commands: wait cmd that gives back the connected replicas
- wait cmd that gives back the connected replicas
- Merge pull request #4 from JayeshBaldawa/3-wait-with-no-replicas: add support for wait command